### PR TITLE
Make PFDA vignette not stop on error

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: faust
 Title: Full Annotation Using Shape-constrained Trees
-Version: 0.5.5
+Version: 0.5.6
 Authors@R: c(person("Evan", "Greene", email = "egreene@fredhutch.org", role = c("aut", "cre")),
    	   person("Laurie", "Davies", role = c("ctb")),	       
 	   person("J.R.M.", "Hosking", role=c("ctb")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: faust
 Title: Full Annotation Using Shape-constrained Trees
-Version: 0.5.6
+Version: 0.6.0
 Authors@R: c(person("Evan", "Greene", email = "egreene@fredhutch.org", role = c("aut", "cre")),
    	   person("Laurie", "Davies", role = c("ctb")),	       
 	   person("J.R.M.", "Hosking", role=c("ctb")),

--- a/R/faust.R
+++ b/R/faust.R
@@ -96,14 +96,37 @@
 #' to marker names in the active channels vector to which supervision is
 #' applied. Channels named in this list will have their gate locations modified.
 #'
-#' Supported supervision: 'Preference'. Asserts a preference for the number of
-#' annotation boundaries for a targeted marker. If this is selected, FAUST will
-#' attempt to standardize to the preferred number of boundaries across experimental
-#' units if there is empirical data to support the preference.
+#' Supported supervision: 
+#' 'Preference'. Asserts a preference for the number of annotation boundaries for 
+#' a targeted marker. If this is selected, FAUST will attempt to standardize to the 
+#' preferred number of boundaries across experimental units if there is empirical 
+#' data to support the preference.
 #'
 #' Example syntax:
-#' 
 #' supervisedList <- list(`Target_Marker` = list(actionType = "Preference", action = c(2)))
+#' 
+#' 'Force'. Forces the gate location for a targeted marker to a specific value. 
+#' 
+#' Example syntax:
+#' supervisedList <- list(`Target_Marker` = list(actionType = "Force", action = c(1000)))
+#' 
+#' 'PostSelection'. Shrinks the range of annotation boundaries for a targeted marker. 
+#' The user specifies a pair of quantiles for each gate selected for the targeted 
+#' marker. All annotation boundaries for the associated gate which are lower than the 
+#' first quantile will be set equal to the value at that quantile, while all 
+#' annotation boundaries more extreme than the second quantile will be set equal to the 
+#' value at that quantile. If the number of sets of quantiles specified is not equal
+#' to the number of gates identified, the first set of quantiles will be used for all
+#' gates.
+#' 
+#' The default is to shrink the annotation boundaries of all markers to the range of 
+#' the first and the ninth deciles.
+#' 
+#' Example syntax:
+#' supervisedList <- list(
+#'      `Target_Marker1` = list(actionType = "PostSelection", action = list(c(0, 1))),
+#'      `Target_Marker2` = list(actionType = "PostSelection", action = list(c(0.2, 0.8), c(0.5, 0.9)))
+#' )
 #'
 #' @param debugFlag Boolean value. Set to TRUE to print method status information
 #' to the console or a log file.

--- a/R/initializeFaustDataDir.R
+++ b/R/initializeFaustDataDir.R
@@ -81,10 +81,12 @@
                           "channelBounds.rds"))
     }
 
-    #always sanitize the starting cell pop for problem characters.
-    sanitizedCellPopStr <- gsub("[[:punct:]]","",startingCellPop)
-    sanitizedCellPopStr <- gsub("[[:space:]]","",sanitizedCellPopStr)
-    sanitizedCellPopStr <- gsub("[[:cntrl:]]","",sanitizedCellPopStr)
+    # always sanitize the starting cell pop for problem characters.
+    # startingCellPop is a user-inputted parameter, and is often set to "root"
+    sanitizedCellPopStr <- gsub("[[:punct:]]","",startingCellPop)     # remove all punctuation from startingCellPop
+    sanitizedCellPopStr <- gsub("[[:space:]]","",sanitizedCellPopStr) # remove all spaces
+    sanitizedCellPopStr <- gsub("[[:cntrl:]]","",sanitizedCellPopStr) # remove all control chars e.g. \n, \r, \t
+    # sanitizedCellPopStr is startingCellPop w/o punctuation, spaces, control chars
     saveRDS(sanitizedCellPopStr,
             file.path(normalizePath(projectPath),
                       "faustData",

--- a/R/initializeFaustDataDir.R
+++ b/R/initializeFaustDataDir.R
@@ -95,7 +95,7 @@
 
     #always update the supervision artifacts in the metaData direcotry
     forceList <- selectionList <- preferenceList <- list()
-    if (!is.na(supervisedList)) {
+    if (any(!is.na(supervisedList))) {
         #supervisedList is a named list of lists
         #name of slot in list: marker
         #list under marker slot 1: string describing type of supervision.

--- a/R/reconcileAnnotationBoundaries.R
+++ b/R/reconcileAnnotationBoundaries.R
@@ -193,7 +193,7 @@
                 naNames <- names(which(is.na(resListUpdate)))
                 for (changeName in naNames) {
                     modVals <- gateList[[changeName]][[channel]]
-                    if (!is.na(modVals)) {
+                    if (any(!is.na(modVals))) {
                         #there is empirical data for an experimental unit, so attempt to use it.
                         #this can arise if the "Preference" setting of supervision leads to using
                         #a gateNumber that is absent from a level of the imputation hierarchy.

--- a/R/superviseReconciliation.R
+++ b/R/superviseReconciliation.R
@@ -1,29 +1,3 @@
-
-projectPath = "../DataProcessed25DLCICEPipeline/_tmp/a055/faust_v1"
-debugFlag = TRUE
-
-# New format of supervisedList
-supervisedList = list("CD3" = list("actionType" = "PostSelection", action = list(c(0.1, 0.9))),
-                     "CD4" = list("actionType" = "PostSelection", action = list(c(0.1, 0.9), c(0.25, 0.75))),
-                     "CD8" = list("actionType" = "PostSelection", action = list(c(0.1, 0.9))),
-                     "HLADR" = list("actionType" = "PostSelection", action = list(c(0.1, 0.9))),
-                     "Perforin" = list("actionType" = "PostSelection", action = list(c(0.1, 0.9))))
-
-# Old format of supervisedList
-# supervisedList = list("CD3" = list("actionType" = "PostSelection", action = c(0.1, 0.9)),
-#                      "CD4" = list("actionType" = "PostSelection", action = c(0.1, 0.9)),
-#                      "CD8" = list("actionType" = "PostSelection", action = c(0.1, 0.9)),
-#                      "HLADR" = list("actionType" = "PostSelection", action = c(0.1, 0.9)),
-#                      "Perforin" = list("actionType" = "PostSelection", action = c(0.1, 0.9)))
-
-# selectionList = list(
-#         "CD3" = list(c(0.1, 0.9)),
-#         "CD4" = list(c(0.1, 0.9), c(0.25, 0.75)),
-#         "CD8" = list(c(0.1, 0.9)),
-#         "HLADR" = list(c(0.1, 0.9)),
-#         "Perforin" = list(c(0.1, 0.9))
-#     )
-
 .superviseReconciliation <- function(projectPath,debugFlag)
 {
     # parentNode is whatever is stored in the sanitizedCellPopStr.rds file - often "root"
@@ -56,16 +30,24 @@ supervisedList = list("CD3" = list("actionType" = "PostSelection", action = list
             print("Proceding as if these are controlled values.")
         }
         for (channel in supervisedChannels) {
-            # use the selection list to set the standard
-            # current annotation boundaries
+            # current annotation boundaries:
             tmpList <- outList[[channel]] 
+
             # user-specified quantiles which extreme annotation values should be shrunk towards
             supervision <- selectionList[[channel]] 
+
+            # Inform user if they specified the incorrect number of quantiles
+            if(length(supervision) != length(tmpList[[1]])){
+                print(paste0(length(supervision)," quantile set(s) was/were provided for channel ", channel, " but ", length(tmpList[[1]])," gate(s) was/were identified." ))
+                print("Using the first quantile set for all gates.")
+                dif_lengths = TRUE
+            }
             
             # for each annotation boundary for a given sample and marker
             for(i in 1:length(tmpList[[1]])){
-                vals = sapply(tmpList, function(x) x[i]) # get all of the ith annotation boundaries
-                boundaries = quantile(vals, supervision[[i]]) # 1 -> i if allow dif quantiles to be specified for dif gates
+                # calculate desired upper and lower bounds
+                vals = sapply(tmpList, function(x) x[i]) 
+                boundaries = quantile(vals, supervision[[ifelse(dif_lengths,1,i)]]) 
 
                 # for each gate for the ith annotation boundary
                 for(gate_num in 1:length(tmpList)){

--- a/R/superviseReconciliation.R
+++ b/R/superviseReconciliation.R
@@ -38,9 +38,8 @@
             
             # for each annotation boundary for a given sample and marker
             for(i in 1:length(tmpList[[1]])){
-                # i = 1
                 vals = sapply(tmpList, function(x) x[i]) # get all of the ith annotation boundaries
-                boundaries = quantile(vals, supervision$action)
+                boundaries = quantile(vals, supervision[[1]]) # 1 -> i if allow dif quantiles to be specified for dif gates
 
                 # for each gate for the ith annotation boundary
                 for(gate_num in 1:length(tmpList)){
@@ -51,9 +50,7 @@
                         tmpList[[gate_num]][i] <- boundaries[2]
                     }
                 } # could make more efficient if we sort tmpList first
-
             }
-
             outList[[channel]] <- tmpList
         }
         # save the updated annotation boundaries
@@ -78,7 +75,3 @@
     }
     return()
 }
-
-
-
-

--- a/R/superviseReconciliation.R
+++ b/R/superviseReconciliation.R
@@ -1,86 +1,86 @@
-.superviseReconciliation <- function(projectPath,debugFlag)
+.superviseReconciliation <- function(projectPath, debugFlag)
 {
     # parentNode is whatever is stored in the sanitizedCellPopStr.rds file - often "root"
     parentNode <- readRDS(file.path(normalizePath(projectPath),
                                     "faustData",
                                     "metaData",
                                     "sanitizedCellPopStr.rds"))
+
     # selectionList is a list of the items from the user-specified "supervisedList" which have actionType == "PostSelection"
-    selectionList <- readRDS(file.path(normalizePath(projectPath),
+    selectionListUser <- readRDS(file.path(normalizePath(projectPath),
                                        "faustData",
                                        "metaData",
                                        "selectionList.rds"))
+    userSpecifiedChannels <- names(selectionListUser)
+    
+    if (debugFlag) print("Selection specific reconciled annotation boundaries.")
 
-    if (length(selectionList) > 0){
-        if (debugFlag) print("Selection specific reconciled annotation boundaries.")
-        # resListPrep contains the annotation boundaries for all the markers, 
-        # post accounting for forcing and preference, but not yet post-selection.
-        resListPrep <- readRDS(file.path(normalizePath(projectPath),
-                                         "faustData",
-                                         "gateData",
-                                         paste0(parentNode,"_resListPrep.rds")))
-        outList <- resListPrep
-        # all of the selected channels 
-        selectedChannels <- names(resListPrep)
-        # all of the channels the user wants to shrink
-        supervisedChannels <- names(selectionList)
-        if (length(setdiff(supervisedChannels,selectedChannels))) {
-            print("The following unselected channels (by depth score) are detected.")
-            print(setdiff(supervisedChannels,selectedChannels))
-            print("Proceding as if these are controlled values.")
-        }
-        for (channel in supervisedChannels) {
-            # current annotation boundaries:
-            tmpList <- outList[[channel]] 
-
-            # user-specified quantiles which extreme annotation values should be shrunk towards
-            supervision <- selectionList[[channel]] 
-
-            # Inform user if they specified the incorrect number of quantiles
-            difLen <- FALSE
-            if(length(supervision) != length(tmpList[[1]])){
-                print(paste0(length(supervision)," quantile set(s) was/were provided for channel ", channel, " but ", length(tmpList[[1]])," gate(s) was/were identified." ))
-                print("Using the first quantile set for all gates.")
-                difLen <- TRUE
+    # resListPrep contains the annotation boundaries for all the markers, 
+    # post accounting for forcing and preference, but not yet post-selection.
+    resListPrep <- readRDS(file.path(normalizePath(projectPath),
+                                        "faustData",
+                                        "gateData",
+                                        paste0(parentNode,"_resListPrep.rds")))
+    outList <- resListPrep
+    # all channel names
+    selectedChannels <- names(resListPrep)
+    # create default list: c(0.1, 0.9) for each gate on each marker
+    selectionList         <- list()
+    length(selectionList) <- length(selectedChannels)
+    names(selectionList)  <- selectedChannels
+    # for each gate in each channel, set the quantiles
+    for(channel in selectedChannels){
+        # If the user has specified quantiles for this channel, use them.
+        if(channel %in% userSpecifiedChannels){
+            specifiedQuantiles <- selectionListUser[[channel]]
+        }else{ 
+            # Otherwise, use the default quantiles of c(0.1, 0.9) for each gate.
+            specifiedQuantiles <- list()
+            for(gate in 1:length(outList[[channel]][[1]])){
+                specifiedQuantiles <- append(specifiedQuantiles, list(c(0.1, 0.9))) # default
             }
-            
-            # for each annotation boundary for a given sample and marker
-            for(gateNum in 1:length(tmpList[[1]])){
-                # calculate desired upper and lower bounds
-                vals <- sapply(tmpList, function(x) x[gateNum]) 
-                boundaries <- quantile(vals, supervision[[ifelse(difLen,1,gateNum)]]) 
-
-                # for each gate for the ith annotation boundary
-                for(sampleNum  in 1:length(tmpList)){
-                    # all gates lower than boundaries[1] are set to boundaries[1]
-                    if(tmpList[[sampleNum ]][gateNum]  < boundaries[1]){
-                        tmpList[[sampleNum ]][gateNum] <- boundaries[1]
-                    } else if(tmpList[[sampleNum ]][gateNum]  > boundaries[2]){
-                        tmpList[[sampleNum ]][gateNum] <- boundaries[2]
-                    }
-                } # could make more efficient if we sort tmpList first
-            }
-            outList[[channel]] <- tmpList
         }
-        # save the updated annotation boundaries
-        saveRDS(outList,
-                file.path(normalizePath(projectPath),
-                          "faustData",
-                          "gateData",
-                          paste0(parentNode,"_resList.rds")))
-    } else {
-        # If selectionList empty _resListPrep.rds is copied to _resList.rds
-        file.copy(
-            from <- file.path(normalizePath(projectPath),
-                             "faustData",
-                             "gateData",
-                             paste0(parentNode,"_resListPrep.rds")),
-            to <- file.path(normalizePath(projectPath),
-                           "faustData",
-                           "gateData",
-                           paste0(parentNode,"_resList.rds")),
-            overwrite <- TRUE
-        )
+        selectionList[[channel]] <- specifiedQuantiles
     }
+
+    for (channel in selectedChannels) {
+        # current annotation boundaries:
+        tmpList <- outList[[channel]] 
+
+        # user-specified quantiles which extreme annotation values should be shrunk towards
+        supervision <- selectionList[[channel]] 
+
+        # Inform user if they specified the incorrect number of quantiles
+        difLen <- FALSE
+        if(length(supervision) != length(tmpList[[1]])){
+            print(paste0(length(supervision)," quantile set(s) was/were provided for channel ", channel, " but ", length(tmpList[[1]])," gate(s) was/were identified." ))
+            print("Using the first quantile set for all gates.")
+            difLen <- TRUE
+        }
+        
+        # for each annotation boundary for a given sample and marker
+        for(gateNum in 1:length(tmpList[[1]])){
+            # calculate desired upper and lower bounds
+            vals <- sapply(tmpList, function(x) x[gateNum]) 
+            boundaries <- quantile(vals, supervision[[ifelse(difLen,1,gateNum)]]) 
+
+            # for each gate for the ith annotation boundary
+            for(sampleNum  in 1:length(tmpList)){
+                # all gates lower than boundaries[1] are set to boundaries[1]
+                if(tmpList[[sampleNum ]][gateNum]  < boundaries[1]){
+                    tmpList[[sampleNum ]][gateNum] <- boundaries[1]
+                } else if(tmpList[[sampleNum ]][gateNum]  > boundaries[2]){
+                    tmpList[[sampleNum ]][gateNum] <- boundaries[2]
+                }
+            } # could make more efficient if we sort tmpList first
+        }
+        outList[[channel]] <- tmpList
+    }
+    # save the updated annotation boundaries
+    saveRDS(outList,
+            file.path(normalizePath(projectPath),
+                        "faustData",
+                        "gateData",
+                        paste0(parentNode,"_resList.rds")))
     return()
 }

--- a/R/superviseReconciliation.R
+++ b/R/superviseReconciliation.R
@@ -1,7 +1,3 @@
-
-projectPath = projr::projr_path_get("cache-a055", "faust_v1")
-debugFlag = TRUE
-
 .superviseReconciliation <- function(projectPath,debugFlag)
 {
     # parentNode is whatever is stored in the sanitizedCellPopStr.rds file - often "root"
@@ -14,14 +10,6 @@ debugFlag = TRUE
                                        "faustData",
                                        "metaData",
                                        "selectionList.rds"))
-
-    selectionList = list(
-        "CD3" = list("actionType" = "PostSelection", action = c(0.45, 0.55)),
-        "CD4" = list("actionType" = "PostSelection", action = c(0.45, 0.55)),
-        "CD8" = list("actionType" = "PostSelection", action = c(0.45, 0.55)),
-        "HLADR" = list("actionType" = "PostSelection", action = c(0.45, 0.55)),
-        "Perforin" = list("actionType" = "PostSelection", action = c(0.45, 0.55))
-    )
 
     if (length(selectionList) > 0){
         if (debugFlag) print("Selection specific reconciled annotation boundaries.")
@@ -42,8 +30,6 @@ debugFlag = TRUE
             print("Proceding as if these are controlled values.")
         }
         for (channel in supervisedChannels) {
-            # channel = "CD4"
-            # channel = "HLADR"
             # use the selection list to set the standard
             # current annotation boundaries
             tmpList <- outList[[channel]] 
@@ -69,7 +55,6 @@ debugFlag = TRUE
             }
 
             outList[[channel]] <- tmpList
-            # unique(as.numeric(tmpList))
         }
         # save the updated annotation boundaries
         saveRDS(outList,

--- a/R/superviseReconciliation.R
+++ b/R/superviseReconciliation.R
@@ -37,18 +37,18 @@
             supervision <- selectionList[[channel]] 
 
             # Inform user if they specified the incorrect number of quantiles
-            dif_lengths <- FALSE
+            difLen <- FALSE
             if(length(supervision) != length(tmpList[[1]])){
                 print(paste0(length(supervision)," quantile set(s) was/were provided for channel ", channel, " but ", length(tmpList[[1]])," gate(s) was/were identified." ))
                 print("Using the first quantile set for all gates.")
-                dif_lengths <- TRUE
+                difLen <- TRUE
             }
             
             # for each annotation boundary for a given sample and marker
             for(gateNum in 1:length(tmpList[[1]])){
                 # calculate desired upper and lower bounds
                 vals <- sapply(tmpList, function(x) x[gateNum]) 
-                boundaries <- quantile(vals, supervision[[ifelse(dif_lengths,1,gateNum)]]) 
+                boundaries <- quantile(vals, supervision[[ifelse(difLen,1,gateNum)]]) 
 
                 # for each gate for the ith annotation boundary
                 for(sampleNum  in 1:length(tmpList)){

--- a/R/superviseReconciliation.R
+++ b/R/superviseReconciliation.R
@@ -37,25 +37,26 @@
             supervision <- selectionList[[channel]] 
 
             # Inform user if they specified the incorrect number of quantiles
+            dif_lengths <- FALSE
             if(length(supervision) != length(tmpList[[1]])){
                 print(paste0(length(supervision)," quantile set(s) was/were provided for channel ", channel, " but ", length(tmpList[[1]])," gate(s) was/were identified." ))
                 print("Using the first quantile set for all gates.")
-                dif_lengths = TRUE
+                dif_lengths <- TRUE
             }
             
             # for each annotation boundary for a given sample and marker
-            for(i in 1:length(tmpList[[1]])){
+            for(gateNum in 1:length(tmpList[[1]])){
                 # calculate desired upper and lower bounds
-                vals = sapply(tmpList, function(x) x[i]) 
-                boundaries = quantile(vals, supervision[[ifelse(dif_lengths,1,i)]]) 
+                vals <- sapply(tmpList, function(x) x[gateNum]) 
+                boundaries <- quantile(vals, supervision[[ifelse(dif_lengths,1,gateNum)]]) 
 
                 # for each gate for the ith annotation boundary
-                for(gate_num in 1:length(tmpList)){
+                for(sampleNum  in 1:length(tmpList)){
                     # all gates lower than boundaries[1] are set to boundaries[1]
-                    if(tmpList[[gate_num]][i]  < boundaries[1]){
-                        tmpList[[gate_num]][i] <- boundaries[1]
-                    } else if(tmpList[[gate_num]][i]  > boundaries[2]){
-                        tmpList[[gate_num]][i] <- boundaries[2]
+                    if(tmpList[[sampleNum ]][gateNum]  < boundaries[1]){
+                        tmpList[[sampleNum ]][gateNum] <- boundaries[1]
+                    } else if(tmpList[[sampleNum ]][gateNum]  > boundaries[2]){
+                        tmpList[[sampleNum ]][gateNum] <- boundaries[2]
                     }
                 } # could make more efficient if we sort tmpList first
             }
@@ -70,15 +71,15 @@
     } else {
         # If selectionList empty _resListPrep.rds is copied to _resList.rds
         file.copy(
-            from = file.path(normalizePath(projectPath),
+            from <- file.path(normalizePath(projectPath),
                              "faustData",
                              "gateData",
                              paste0(parentNode,"_resListPrep.rds")),
-            to = file.path(normalizePath(projectPath),
+            to <- file.path(normalizePath(projectPath),
                            "faustData",
                            "gateData",
                            paste0(parentNode,"_resList.rds")),
-            overwrite = TRUE
+            overwrite <- TRUE
         )
     }
     return()

--- a/R/superviseReconciliation.R
+++ b/R/superviseReconciliation.R
@@ -1,3 +1,29 @@
+
+projectPath = "../DataProcessed25DLCICEPipeline/_tmp/a055/faust_v1"
+debugFlag = TRUE
+
+# New format of supervisedList
+supervisedList = list("CD3" = list("actionType" = "PostSelection", action = list(c(0.1, 0.9))),
+                     "CD4" = list("actionType" = "PostSelection", action = list(c(0.1, 0.9), c(0.25, 0.75))),
+                     "CD8" = list("actionType" = "PostSelection", action = list(c(0.1, 0.9))),
+                     "HLADR" = list("actionType" = "PostSelection", action = list(c(0.1, 0.9))),
+                     "Perforin" = list("actionType" = "PostSelection", action = list(c(0.1, 0.9))))
+
+# Old format of supervisedList
+# supervisedList = list("CD3" = list("actionType" = "PostSelection", action = c(0.1, 0.9)),
+#                      "CD4" = list("actionType" = "PostSelection", action = c(0.1, 0.9)),
+#                      "CD8" = list("actionType" = "PostSelection", action = c(0.1, 0.9)),
+#                      "HLADR" = list("actionType" = "PostSelection", action = c(0.1, 0.9)),
+#                      "Perforin" = list("actionType" = "PostSelection", action = c(0.1, 0.9)))
+
+# selectionList = list(
+#         "CD3" = list(c(0.1, 0.9)),
+#         "CD4" = list(c(0.1, 0.9), c(0.25, 0.75)),
+#         "CD8" = list(c(0.1, 0.9)),
+#         "HLADR" = list(c(0.1, 0.9)),
+#         "Perforin" = list(c(0.1, 0.9))
+#     )
+
 .superviseReconciliation <- function(projectPath,debugFlag)
 {
     # parentNode is whatever is stored in the sanitizedCellPopStr.rds file - often "root"
@@ -39,7 +65,7 @@
             # for each annotation boundary for a given sample and marker
             for(i in 1:length(tmpList[[1]])){
                 vals = sapply(tmpList, function(x) x[i]) # get all of the ith annotation boundaries
-                boundaries = quantile(vals, supervision[[1]]) # 1 -> i if allow dif quantiles to be specified for dif gates
+                boundaries = quantile(vals, supervision[[i]]) # 1 -> i if allow dif quantiles to be specified for dif gates
 
                 # for each gate for the ith annotation boundary
                 for(gate_num in 1:length(tmpList)){

--- a/R/superviseReconciliation.R
+++ b/R/superviseReconciliation.R
@@ -1,22 +1,28 @@
 .superviseReconciliation <- function(projectPath,debugFlag)
 {
-
+    # parentNode is whatever is stored in the sanitizedCellPopStr.rds file - often "root"
     parentNode <- readRDS(file.path(normalizePath(projectPath),
                                     "faustData",
                                     "metaData",
                                     "sanitizedCellPopStr.rds"))
+    # selectionList is a list of the items from the user-specified "supervisedList" which have actionType == "PostSelection"
     selectionList <- readRDS(file.path(normalizePath(projectPath),
                                        "faustData",
                                        "metaData",
                                        "selectionList.rds"))
+
     if (length(selectionList) > 0){
         if (debugFlag) print("Selection specific reconciled annotation boundaries.")
+        # resListPrep contains the annotation boundaries for all the markers, 
+        # post accounting for forcing and preference, but not yet post-selection.
         resListPrep <- readRDS(file.path(normalizePath(projectPath),
                                          "faustData",
                                          "gateData",
                                          paste0(parentNode,"_resListPrep.rds")))
         outList <- resListPrep
+        # all of the selected channels 
         selectedChannels <- names(resListPrep)
+        # all of the channels the user wants to shrink
         supervisedChannels <- names(selectionList)
         if (length(setdiff(supervisedChannels,selectedChannels))) {
             print("The following unselected channels (by depth score) are detected.")
@@ -24,29 +30,28 @@
             print("Proceding as if these are controlled values.")
         }
         for (channel in supervisedChannels) {
-            #use the selection list to set the standard
-            tmpList <- outList[[channel]]
-            supervision <- selectionList[[channel]]
-            if (length(supervision) > length(tmpList[[1]])) {
-                stop("Attempting to set more gates than exist post-reconciliation.")
-            }
-            if (max(supervision) > length(tmpList[[1]])) {
-                stop("Attempting to set a gate beyond the last gate existing post-reconciliation.")
-            }
-            if (min(supervision) < 1) {
-                stop("Attempting to set a gate beneath the first gate existing post-reconciliation.")
-            }
-            for (gateNum in seq(length(tmpList))) {
-                tmpList[[gateNum]] <- tmpList[[gateNum]][supervision]
-            }
+            # use the selection list to set the standard
+            # current annotation boundaries
+            tmpList <- outList[[channel]] 
+            # user-specified quantiles which extreme annotation values should be shrunk towards
+            supervision <- selectionList[[channel]] 
+            # tmpList[[1]] contains gates for channel for all samples
+            boundaries = quantile(as.numeric(resListPrep[["Ki67"]]), c(0.1, 0.9))
+            # all gates lower than boundaries[1] are set to boundaries[1]
+            for(gate_num in 1:length(tmpList)){
+                if(tmpList[[gate_num]] < boundaries[[1]]){tmpList[[gate_num]][1] <- boundaries[1]}
+                else if(tmpList[[gate_num]] > boundaries[2]){tmpList[[gate_num]][1] <- boundaries[2]}
+            } # could make more efficient if we sort tmpList first
             outList[[channel]] <- tmpList
         }
+        # save the updated annotation boundaries
         saveRDS(outList,
                 file.path(normalizePath(projectPath),
                           "faustData",
                           "gateData",
                           paste0(parentNode,"_resList.rds")))
     }
+    # If selectionList empty _resListPrep.rds is copied to _resList.rds
     else {
         file.copy(
             from = file.path(normalizePath(projectPath),
@@ -62,5 +67,7 @@
     }
     return()
 }
+
+
 
 

--- a/R/validateForestParameters.R
+++ b/R/validateForestParameters.R
@@ -19,12 +19,12 @@
     {
         stop("annotationsApproved must be set to a single boolean value.")
     }
-    if ((!is.na(supervisedList)) && (length(setdiff(names(supervisedList),activeChannels))))
+    if ((any(!is.na(supervisedList))) && (length(setdiff(names(supervisedList),activeChannels))))
     {
         print("supervisedList is attempting to supervise a channel")
         stop("not in the activeChannels vector.")
     }
-    if ((!is.na(supervisedList)) && (length(supervisedList) > length(activeChannels)))
+    if ((any(!is.na(supervisedList))) && (length(supervisedList) > length(activeChannels)))
     {
         print("supervisedList is attempting to supervise more channels")
         stop("than those listed in the activeChannels vector.")
@@ -142,7 +142,7 @@
     {
         stop("debugFlag must be set to TRUE xor FALSE.")
     }
-    if ((!is.na(supervisedList)) && (!is.list(supervisedList)))
+    if ((any(!is.na(supervisedList))) && (!is.list(supervisedList)))
     {
         stop("supervisedList must be a named list.")
     }

--- a/vignettes/faustPFDA.Rmd
+++ b/vignettes/faustPFDA.Rmd
@@ -12,7 +12,8 @@ vignette: >
 ```{r setup, include = FALSE}
 knitr::opts_chunk$set(
   comment = "#>",
-  dpi = 300
+  dpi = 300,
+  error = TRUE
 )
 ```
 


### PR DESCRIPTION
Running on CentOS 7 with R 4.1.2 with fully-updated packages on 2022 March 17 produced the following error

```
   --- re-building ‘faustPFDA.Rmd’ using rmarkdown
   Quitting from lines 426-439 (faustPFDA.Rmd) 
   Error: processing vignette 'faustPFDA.Rmd' failed with diagnostics:
   Downdated VtV is not positive definite
   --- failed re-building ‘faustPFDA.Rmd’
``` 

when building vignettes on install, which blocked the install. To allow the Rmd to complete even with the error (and allow at least to see part of that vignette and the other two vignettes when installing with vignettes), I added `error = TRUE` as an argument to `knitr::opts_chunk$set`.

Of course, it would be better to fix the error, but this at least allows installation with two out of three vignettes.

Attached is a PDF of the output from running the PFDA vignette. 
[FAUST PFDA.pdf](https://github.com/RGLab/FAUST/files/8282216/FAUST.PFDA.pdf)